### PR TITLE
[FIX] Models scan: support list in `_inherit` attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ ENV/
 
 # Lint
 /.ruff_cache
+
+# Tests cache
+.odoo_download_dir_path/

--- a/odoo_addons_parser/code.py
+++ b/odoo_addons_parser/code.py
@@ -165,9 +165,19 @@ class OdooModel:
                     # _name, _inherit, _description, _auto, _order...
                     if isinstance(elt.value, ast.Constant):
                         return elt.value.value
-                    # _inherit
-                    if isinstance(elt.value, ast.Constant):
-                        return elt.value.value
+                    #  _inherit = [...]
+                    if isinstance(elt.value, ast.List):
+                        values = []
+                        for e in elt.value.elts:
+                            # e.g. = ['my.model']
+                            if isinstance(e, ast.Constant):
+                                values.append(e.value)
+                            # e.g. = [_name]
+                            if isinstance(e, ast.Name):
+                                value = OdooModel._get_attr_value(ast_cls, e.id)
+                                if value:
+                                    values.append(value)
+                        return values
                     # _inherits
                     if isinstance(elt.value, ast.Dict):
                         # iterate on dict keys/values

--- a/odoo_addons_parser/module.py
+++ b/odoo_addons_parser/module.py
@@ -106,6 +106,11 @@ class ModuleParser:
         data = pyfile.to_dict()
         for model in data["models"].values():
             key = model.get("name") or model.get("inherit")
+            if isinstance(key, list):
+                # Data model declared without `_name` but with `_inherit = [...]`,
+                # e.g. `_inherit = ['res.partner']`, considers - like Odoo - first
+                # element as current model name
+                key = key[0]
             if key not in self.models:
                 self.models.setdefault(key, {}).update(model)
             else:

--- a/odoo_addons_parser/tests/common.py
+++ b/odoo_addons_parser/tests/common.py
@@ -21,7 +21,7 @@ class CommonCase(unittest.TestCase):
         cls.module_code_stats = {
             "CSS": 0,
             "JavaScript": 0,
-            "Python": 19,
+            "Python": 23,
             "XML": 14,
         }
         cls.module_manifest = {
@@ -82,7 +82,14 @@ class CommonCase(unittest.TestCase):
                     },
                 },
                 "type": "Model",
-            }
+            },
+            "res.users": {
+                "file_path": "models/res_users.py",
+                "class_name": "ResUsers",
+                "name": "res.users",
+                "inherit": ["res.users", "test"],
+                "type": "Model",
+            },
         }
         cls.module_to_dict = {
             "name": cls.module_name,

--- a/odoo_addons_parser/tests/repo/module_test/models/res_users.py
+++ b/odoo_addons_parser/tests/repo/module_test/models/res_users.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Sebastien Alix <https://github.com/sebalix>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+# Test corner case: inherit declared as a list + ref to cls variable
+class ResUsers(models.Model):
+    _name = "res.users"
+    _inherit = [_name, "test"]


### PR DESCRIPTION
Like:
```python
class ResPartner(models.Model):
    _inherit = ["res.partner"]
```