### PR TITLE
[FIX] Qualify data models as original/new in a module

### DIFF
--- a/odoo_addons_parser/module.py
+++ b/odoo_addons_parser/module.py
@@ -118,6 +118,13 @@ class ModuleParser:
                     self.models[key].setdefault("fields", {}).update(model["fields"])
                 if model.get("methods"):
                     self.models[key].setdefault("methods", {}).update(model["methods"])
+                # Handle cases where more than one file declare the same data model
+                # in current scanned module, and one of them is the original
+                # declaration w/o inheritance).
+                #   => Consider the data model as original/new for current module.
+                if model.get("name") == key and self.models[key].get("inherit") == key:
+                    self.models[key]["name"] = key
+                    del self.models[key]["inherit"]
 
     def to_dict(self) -> dict:
         data = {

--- a/odoo_addons_parser/tests/test_odoo.py
+++ b/odoo_addons_parser/tests/test_odoo.py
@@ -67,3 +67,17 @@ class TestOdoo(common.CommonCase):
             self.assertIn("Model", framework_models)
             self.assertIn("TransientModel", framework_models)
             self.assertIn("res.partner", list(data["base"]["models"]))
+            # 'res.partner' and 'res.users' are declared several times in 'base'
+            # module (one with '_name' and another ones with '_inherit'), but it's
+            # not considered as inherited at the module level (ignoring any use
+            # of '_inherit')
+            for model in ("res.partner", "res.users"):
+                record = data["base"]["models"][model]
+                self.assertIn("name", record)
+                self.assertTrue(record["name"], model)
+                self.assertNotIn(model, record.get("inherit", ""))
+            # While in 'sale' it is inheriting 'res.partner'
+            sale_res_partner = data["sale"]["models"]["res.partner"]
+            self.assertNotIn("name", sale_res_partner)
+            self.assertIn("inherit", sale_res_partner)
+            self.assertIn("res.partner", sale_res_partner["inherit"])


### PR DESCRIPTION
Even if it is declared several times (with `_name` and `_inherit`) in the module (e.g. like `res.users` in `base` module).