### PR TITLE
[IMP] Parse Odoo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
-[![Pre-commit Status](https://github.com/sebalix/odoo-addons-parser/actions/workflows/pre-commit.yml/badge.svg?branch=main)](https://github.com/sebalix/odoo-addons-parser/actions/workflows/pre-commit.yml?query=branch%3Amain)
-[![Tests Status](https://github.com/sebalix/odoo-addons-parser/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/sebalix/odoo-addons-parser/actions/workflows/test.yml?query=branch%3Amain)
-[![Last version](https://img.shields.io/pypi/v/odoo-addons-parser)](https://pypi.org/project/odoo-addons-parser/)
-
 # odoo-addons-parser
 
-Python package to collect data from Odoo module folders.
+[![Version](https://img.shields.io/pypi/v/odoo-addons-parser.svg?maxAge=86400)](https://pypi.org/project/odoo-addons-parser)
+[![Supported Versions](https://img.shields.io/pypi/pyversions/odoo-addons-parser.svg)](https://pypi.org/project/odoo-addons-parser)
+[![Pre-commit Status](https://github.com/sebalix/odoo-addons-parser/actions/workflows/pre-commit.yml/badge.svg?branch=main)](https://github.com/sebalix/odoo-addons-parser/actions/workflows/pre-commit.yml?query=branch%3Amain)
+[![Tests Status](https://github.com/sebalix/odoo-addons-parser/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/sebalix/odoo-addons-parser/actions/workflows/test.yml?query=branch%3Amain)
 
-Features:
+Python package to collect and analyze data from Odoo module folders without requiring an Odoo runtime. It performs static file analysis to extract useful information from Odoo modules.
 
-- scan an Odoo repository, a folder of modules (repository) or a module only
-- count the number of lines of code (Python, XML, JavaScript and CSS by default)
-- read the manifest file (to get useful data like authors or dependencies)
-- extract Odoo models info (fields, methods, data...)
+## Features
 
-It doesn't rely on any Odoo runtime; instead, it works through static file analysis.
+- **Static Analysis**: Doesn't rely on any Odoo runtime; performs static files analysis
+- **Code Statistics**: Count lines of code (Python, XML, JavaScript, and CSS)
+- **Manifest Parsing**: Extract useful data from manifest files (authors, dependencies, etc.)
+- **Model Extraction**: Extract Odoo models information (with fields and methods)
+- **Data Extraction**: Extract data from XML and CSV files
+- **Flexible Scanning**: Scan individual modules, repositories, or entire Odoo source code
 
-## ModuleParser class
+## Installation
 
-`ModuleParser` class aims to scan a module folder only:
+```bash
+uv pip install odoo-addons-parser
+```
+
+Or with pip:
+```bash
+pip install odoo-addons-parser
+```
+
+## Usage
+
+### ModuleParser
+
+Parse a single Odoo module:
 
 ```python
 from odoo_addons_parser import ModuleParser
@@ -26,103 +40,73 @@ from pprint import pprint as pp
 mod = ModuleParser("/path/to/OCA/server-tools/server_environment")
 pp(mod.to_dict())
 ```
-=>
+
+Example output:
+
 ```python
-{'code': {'CSS': 0, 'JavaScript': 0, 'Python': 541, 'XML': 21},
- 'manifest': {'author': 'Camptocamp,Odoo Community Association (OCA)',
-              'category': 'Tools',
-              'data': ['security/ir.model.access.csv',
-                       'security/res_groups.xml',
-                       'serv_config.xml'],
-              'depends': ['base', 'base_sparse_field'],
-              'installable': True,
-              'license': 'GPL-3 or any later version',
-              'name': 'server configuration environment files',
-              'summary': 'move some configurations out of the database',
-              'version': '14.0.1.0.0',
-              'website': 'https://github.com/OCA/server-env'}},
- 'models': ...
- 'name': 'server_environment',
+{
+    'code': {'CSS': 0, 'JavaScript': 0, 'Python': 541, 'XML': 21},
+    'manifest': {
+        'author': 'Camptocamp,Odoo Community Association (OCA)',
+        'category': 'Tools',
+        'data': ['security/ir.model.access.csv', 'security/res_groups.xml', 'serv_config.xml'],
+        'depends': ['base', 'base_sparse_field'],
+        'installable': True,
+        'license': 'GPL-3 or any later version',
+        'name': 'server configuration environment files',
+        'summary': 'move some configurations out of the database',
+        'version': '14.0.1.0.0',
+        'website': 'https://github.com/OCA/server-env'
+    },
+    'models': ...,
+    'name': 'server_environment'
+}
 ```
 
-## RepositoryParser class
+### RepositoryParser
 
-`RepositoryParser` class aims to scan a whole repository of addons
-(also named *addons path*):
+Parse a whole repository of addons:
 
 ```python
 from odoo_addons_parser import RepositoryParser
+
 repo = RepositoryParser("/path/to/OCA/server-tools")
 pp(repo.to_dict())
 ```
-=>
-```python
-{'data_encryption': {'code': {'CSS': 0,
-                              'JavaScript': 0,
-                              'Python': 187,
-                              'XML': 0},
-                     'manifest': {'application': False,
-                                  'author': 'Akretion, Odoo Community '
-                                            'Association (OCA)',
-                                  'category': 'Tools',
-                                  'data': ['security/ir.model.access.csv'],
-                                  'depends': ['base'],
-                                  'development_status': 'Alpha',
-                                  'external_dependencies': {'python': ['cryptography']},
-                                  'installable': True,
-                                  'license': 'AGPL-3',
-                                  'name': 'Encryption data',
-                                  'summary': 'Store accounts and credentials '
-                                             'encrypted by environment',
-                                  'version': '14.0.1.0.0',
-                                  'website': 'https://github.com/OCA/server-env'},
-                     'models': ...,
-                     'name': 'data_encryption'},
- 'mail_environment': {'code': {'CSS': 0,
-                               'JavaScript': 0,
-                               'Python': 43,
-                               'XML': 0},
-                      'manifest': {'author': 'Camptocamp, Odoo Community '
-                                             'Association (OCA)',
-                                   'category': 'Tools',
-                                   'depends': ['fetchmail',
-                                               'server_environment'],
-                                   'license': 'AGPL-3',
-                                   'name': 'Mail configuration with '
-                                           'server_environment',
-                                   'summary': 'Configure mail servers with '
-                                              'server_environment_files',
-                                   'version': '14.0.1.0.0',
-                                   'website': 'https://github.com/OCA/server-env'},
-                     'models': ...,
-                     'name': 'mail_environment'},
-[...]
-```
 
-## OdooParser class
+### OdooParser
 
-`OdooParser` special class aims to scan the Odoo source code repository
-(the one we clone from https://github.com/odoo/odoo). It'll parse the content
-of `./odoo/addons`, `./addons` and Odoo base classes such as `BaseModel`,
-`Model` and `TransientModel`:
+Parse the Odoo source code repository:
 
 ```python
->>> from odoo_addons_parser import OdooParser
->>> odoo = OdooParser("/path/to/odoo/odoo")
->>> data = odoo.to_dict()
->>> list(data["__odoo__"]["models"])
-["BaseModel", "Model", "TransientModel"]
->>> "res.partner" in data["base"]["models"]
-True
+from odoo_addons_parser import OdooParser
+
+odoo = OdooParser("/path/to/odoo/odoo")
+data = odoo.to_dict()
+list(data["__odoo__"]["models"])
+# ["BaseModel", "Model", "TransientModel"]
+"res.partner" in data["base"]["models"]
+# True
 ```
 
 ## Parameters
 
-Code stats or models scanning can be disabled thanks to `code_stats` and
-`scan_models` parameters, available on all classes:
+You can disable specific features using parameters:
 
 ```python
+# Disable code statistics
 repo = RepositoryParser("path/to/addons_path", code_stats=False)
+
+# Disable model scanning
 mod = ModuleParser("path/to/addons_path/module", scan_models=False)
-odoo = OdooParser("path/to/odoo/odoo", code_stats=False)
+
+# Disable data scanning
+mod = ModuleParser("path/to/addons_path/module", scan_data=False)
+
+# Disable all
+odoo = OdooParser("/path/to/odoo/odoo", code_stats=False, scan_models=False, scan_data=False)
 ```
+
+## License
+
+This project is licensed under the LGPL-3.0 License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Features:
 - scan an Odoo repository, a folder of modules (repository) or a module only
 - count the number of lines of code (Python, XML, JavaScript and CSS by default)
 - read the manifest file (to get useful data like authors or dependencies)
-- extract Odoo models info (fields, methods...)
+- extract Odoo models info (fields, methods, data...)
+
+It doesn't rely on any Odoo runtime; instead, it works through static file analysis.
 
 ## ModuleParser class
 

--- a/odoo_addons_parser/data_csv.py
+++ b/odoo_addons_parser/data_csv.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Sebastien Alix <https://github.com/sebalix>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import csv
+import logging
+import pathlib
+from typing import Any, Dict, List, Optional
+
+_logger = logging.getLogger(__name__)
+
+
+class CsvParseError(Exception):
+    """Exception raised for CSV parsing errors."""
+
+    pass
+
+
+class CsvFile:
+    """Parse and extract data from Odoo CSV files."""
+
+    def __init__(
+        self, module_path: pathlib.Path, file_path: pathlib.Path, loaded: bool = False
+    ):
+        self.module_path = module_path
+        self.module_name = self.module_path.name
+        self.file_path = file_path
+        self.relative_file_path = self.file_path.relative_to(self.module_path)
+        self.loaded = loaded
+        self.model_name = self._extract_model_name()
+        self.records = self._parse_csv()
+
+    def _extract_model_name(self) -> str:
+        """Extract model name from filename.
+
+        E.g. 'res.country.csv' -> 'res.country'.
+        """
+        if self.file_path.name.endswith(".csv"):
+            return self.file_path.stem
+        raise CsvParseError(f"Invalid CSV filename: {self.file_path.name}")
+
+    def _parse_csv(self) -> List[Dict[str, Any]]:
+        """Parse CSV file and return list of records."""
+        records = []
+        try:
+            with open(self.file_path, "r", encoding="utf-8") as file_:
+                reader = csv.DictReader(file_)
+                for row_num, row in enumerate(reader, start=2):
+                    try:
+                        record = self._process_row(row, row_num)
+                        if record:
+                            records.append(record)
+                    except Exception as e:
+                        _logger.warning(
+                            f"Error processing row {row_num} in {self.file_path}: {e}"
+                        )
+                        continue
+        except Exception as e:
+            raise CsvParseError(f"Error reading CSV file {self.file_path}: {e}")
+        return records
+
+    def _process_row(
+        self, row: Dict[str, str], row_num: int
+    ) -> Optional[Dict[str, Any]]:
+        """Process a single CSV row into a structured record."""
+        if not row:
+            return None
+        # Extract data from row
+        data = {}
+        for field_name, value in row.items():
+            if ":" in field_name:
+                # Handle field references like "country_id:id"
+                base_field = field_name.split(":")[0]
+                data[base_field] = value
+            else:
+                data[field_name] = value
+        # Validate required fields
+        if "id" not in data:
+            _logger.warning(f"Row {row_num} missing 'id' field in {self.file_path}")
+            return None
+        # Create structured record
+        record = {
+            "id": data["id"],
+            "model": self.model_name,
+            "file_path": str(self.relative_file_path),
+            "data": data,
+            "loaded": self.loaded,
+        }
+        return record
+
+    def to_dict(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Convert parsed CSV data to dictionary format."""
+        return {self.model_name: self.records}

--- a/odoo_addons_parser/data_xml.py
+++ b/odoo_addons_parser/data_xml.py
@@ -1,0 +1,417 @@
+# Copyright 2025 Sebastien Alix <https://github.com/sebalix>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import xml.etree.ElementTree as ET
+from typing import Dict, Optional, Any
+import pathlib
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class XmlParseError(Exception):
+    """Exception raised for XML parsing errors."""
+
+    pass
+
+
+class XmlValidationError(Exception):
+    """Exception raised for XML validation errors."""
+
+    pass
+
+
+class XmlFile:
+    """XML backend data file.
+
+    Such file could contain record definitions such as views, menu, records...
+    """
+
+    def __init__(
+        self, module_path: pathlib.Path, file_path: pathlib.Path, loaded: bool = False
+    ):
+        self.module_path = module_path
+        self.module_name = self.module_path.name
+        self.file_path = file_path
+        self.relative_file_path = self.file_path.relative_to(self.module_path)
+        self.loaded = loaded
+        self.elements = self._parse_file()
+
+    def _parse_file(self) -> Dict:
+        """Parse the XML file and extract relevant elements."""
+        try:
+            tree = ET.parse(self.file_path)
+            root = tree.getroot()
+            # Handle both 'odoo' and 'openerp' root tags
+            if root.tag not in ("odoo", "openerp"):
+                _logger.warning(f"Unexpected root tag '{root.tag}' in {self.file_path}")
+                return {tag: [] for tag in TAGS}
+            return self._parse_root_node(root)
+        except ET.ParseError as e:
+            _logger.warning(f"XML parse error in {self.file_path}: {e}")
+            return {tag: [] for tag in TAGS}
+        except NotImplementedError:
+            raise
+        except Exception as e:
+            _logger.warning(
+                f"Unexpected error parsing {self.file_path}: {e}", exc_info=True
+            )
+            return {tag: [] for tag in TAGS}
+
+    def _parse_root_node(self, root):
+        elements = {tag: [] for tag in TAGS}
+        # Process direct children
+        for node in root:
+            if node.tag in IGNORED_TAGS:
+                continue
+            # <data> could exist alongside other tags, process it as a root node
+            if node.tag == "data":
+                data_elements = self._parse_root_node(node)
+                for tag, elts in data_elements.items():
+                    elements[tag].extend(elts)
+            # Easy way to know when new Odoo releases introduce new tags: raise
+            elif node.tag not in TAGS:
+                raise NotImplementedError(f"Tag {node.tag} is not supported.")
+            try:
+                parser = TAGS.get(node.tag)
+                if parser:
+                    try:
+                        element = parser(self, node, root_node=root)
+                        elements[node.tag].append(element)
+                    except (XmlValidationError, XmlParseError) as e:
+                        _logger.debug(
+                            f"Skipping invalid {node.tag} in {self.file_path}: {e}"
+                        )
+                        continue
+                    except Exception as e:
+                        _logger.warning(
+                            f"Unexpected error parsing {node.tag} in {self.file_path}: {e}",
+                            exc_info=True,
+                        )
+                        continue
+            except Exception as e:
+                _logger.warning(
+                    f"Failed to parse XML elements in {self.file_path}: {e}",
+                    exc_info=True,
+                )
+                continue
+            # Recursively process nested elements for tags that can contain children
+            if node.tag in ["menuitem"]:
+                nested_elements = self._parse_root_node(node)
+                for tag, elts in nested_elements.items():
+                    elements[tag].extend(elts)
+        return elements
+
+    def to_dict(self) -> Dict:
+        """Convert all elements to simplified dictionary format."""
+        result = {}
+        for tag, elts in self.elements.items():
+            for elt in elts:
+                model_name = elt.model  # Key is the record's model
+                if model_name not in result:
+                    result[model_name] = []
+                result[model_name].append(elt.to_dict())
+        return result
+
+
+class XmlTag:
+    """Base class for Odoo XML tags (record, template, etc.)."""
+
+    _tag = None  # Defined by subclasses
+    _tag_required_attrs = ("id",)
+    _tag_name_attr = "id"
+
+    def __init__(
+        self,
+        xmlfile: XmlFile,
+        node: ET.Element,
+        root_node: ET.Element,
+        model: str,
+    ):
+        self.xmlfile = xmlfile
+        self.node = node
+        self.root_node = root_node
+        self._check_node()
+        self.id_ = node.get("id")
+        self.model = model
+        self.type_ = self._get_type()
+        self.name = self._extract_name()
+        self.data = self._extract_data()
+        self.loaded = self.xmlfile.loaded
+        self.noupdate = self._get_noupdate()
+
+    def _check_node(self):
+        """Check node validity."""
+        for attr in self._tag_required_attrs:
+            if not self.node.get(attr):
+                raise XmlValidationError(
+                    f"Missing required 'id' attribute in <{self._tag}> tag in"
+                    f" {self.xmlfile.file_path}"
+                )
+
+    def _get_type(self) -> Optional[str]:
+        return None
+
+    def _extract_name(self) -> Optional[str]:
+        """Extract the name field from the tag."""
+        return self.node.get(self._tag_name_attr)
+
+    def _extract_data(self) -> Dict:
+        """Extract data from the tag (to be implemented by subclasses)."""
+        raise NotImplementedError("Subclasses must implement _extract_data()")
+
+    def _get_noupdate(self) -> bool:
+        """Extract noupdate attribute from root node."""
+        noupdate = self.root_node.attrib.get("noupdate", "")
+        noupdate = noupdate.strip() if noupdate else noupdate
+        if not noupdate:
+            return False
+        # Values checked copied from 'odoo.tools.convert.str2bool'
+        return noupdate.lower() not in ("0", "false", "off")
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary format."""
+        result = {
+            "id": self.id_,
+            "model": self.model,
+            "file_path": str(self.xmlfile.relative_file_path),
+            "data": self.data,
+            "loaded": self.loaded,
+        }
+        if self.name:
+            result["name"] = self.name
+        if self.type_:
+            result["type"] = self.type_
+        if self.noupdate:
+            result["noupdate"] = True
+        return result
+
+
+class XmlSpecialTag(XmlTag):
+    """Base class for XML special tags with model and attribute-to-field mappings.
+
+    Subclasses should define:
+    - _model: model name this tag represents
+    - _attribute_mapping: dict mapping XML attributes to Odoo fields
+    - _default_data: dict of default field values
+    """
+
+    _model = None  # Defined by subclasses
+    _attribute_mapping: Dict[str, str] = {}
+    _default_data: Dict[str, Any] = {}
+
+    def __init__(
+        self,
+        xmlfile: XmlFile,
+        node: ET.Element,
+        root_node: ET.Element,
+    ):
+        model = self._model
+        if callable(self._model):
+            model = self._model(xmlfile, node)
+        super().__init__(xmlfile, node, root_node, model=model)
+
+    def _extract_data(self) -> Dict:
+        """Extract data using configured attribute mappings."""
+        data = self._default_data.copy()
+        for xml_attr, odoo_field in self._attribute_mapping.items():
+            if value := self.node.get(xml_attr):
+                data[odoo_field] = value
+        return data
+
+
+class XmlRecord(XmlTag):
+    """Representation of an Odoo XML record (`<record>` tag)."""
+
+    _tag = "record"
+    _tag_required_attrs = ("id", "model")
+
+    def __init__(
+        self,
+        xmlfile: XmlFile,
+        node: ET.Element,
+        root_node: ET.Element,
+    ):
+        model = node.get("model")
+        if model is None:
+            raise XmlValidationError(
+                "Missing required 'model' attribute in <record> tag"
+            )
+        super().__init__(xmlfile, node, root_node, model=model)
+        self.target_model = self._extract_target_model()
+
+    def _get_type(self) -> Optional[str]:
+        return "normal" if self.model == "ir.ui.view" else None
+
+    def _extract_name(self) -> Optional[str]:
+        """Extract the name field from the record."""
+        name_field = self._find_field("name")
+        return name_field.text if name_field is not None else None
+
+    def _find_field(self, field_name: str) -> Optional[ET.Element]:
+        """Find a field element by name."""
+        for field in self.node.findall("field"):
+            if field.get("name") == field_name:
+                return field
+        return None
+
+    def _extract_data(self) -> Dict:
+        """Extract all field data from the record."""
+        data = {}
+        for field in self.node.findall("field"):
+            if field_name := field.get("name"):
+                # If field has a 'ref' attribute, use that as the value
+                # This handles cases like <field name="inherit_id" ref="base.view_id"/>
+                if field.get("ref"):
+                    data[field_name] = field.get("ref")
+                else:
+                    # For XML fields, extract the full XML content including child elements
+                    if self.model == "ir.ui.view" and field.get("name") == "arch":
+                        arch = "".join(
+                            ET.tostring(child, encoding="unicode") for child in field
+                        )
+                        data[field_name] = (field.text or "") + arch
+                    else:
+                        # Otherwise use the text content
+                        data[field_name] = field.text
+        return data
+
+    def _extract_target_model(self) -> Optional[str]:
+        """Extract the target model this record applies to."""
+        if self.model in ("ir.ui.view",):
+            return self.data.get("model")
+        elif self.model in ("ir.actions.act_window",):
+            return self.data.get("res_model")
+        elif self.model in ("ir.model.access", "ir.rule"):
+            model_id = self.data.get("model_id", "")
+            return model_id.split(".")[-1] if model_id else None
+        return None
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary format."""
+        result = super().to_dict()
+        if self.target_model:
+            result["target_model"] = self.target_model
+        return result
+
+
+class XmlTemplate(XmlTag):
+    """Representation of an Odoo XML template (`<template>` tag)."""
+
+    _tag = "template"
+
+    def __init__(
+        self,
+        xmlfile: XmlFile,
+        node: ET.Element,
+        root_node: ET.Element,
+    ):
+        super().__init__(xmlfile, node, root_node, model="ir.ui.view")
+
+    def _get_type(self) -> str:
+        # Templates are always ir.ui.view records with type 'qweb'
+        return "qweb"
+
+    def _extract_data(self) -> Dict:
+        """Extract template data and convert to ir.ui.view format."""
+        data = {
+            # Extract arch field - this contains the template content
+            "arch": ET.tostring(self.node, encoding="unicode"),
+        }
+        # Handle template inheritance if present
+        if inherit_id := self.node.get("inherit_id"):
+            data["inherit_id"] = inherit_id
+        return data
+
+
+class XmlMenuItem(XmlSpecialTag):
+    """Representation of an Odoo XML menuitem (`<menuitem>` tag)."""
+
+    _model = "ir.ui.menu"
+    _tag = "menuitem"
+    _tag_name_attr = "name"
+
+    _attribute_mapping = {
+        "name": "name",
+        "parent": "parent_id",
+        "action": "action",
+        "groups": "groups_id",
+    }
+
+    def _extract_data(self) -> Dict:
+        data = super()._extract_data()
+        if not data.get("parent_id") and self.root_node.tag == "menuitem":
+            data["parent_id"] = self.root_node.get("id")
+        return data
+
+
+class XmlAsset(XmlSpecialTag):
+    """Representation of an Odoo XML asset (`<asset>` tag)."""
+
+    _model = lambda self, xmlfile, node: (  # noqa: E731
+        "theme.ir.asset" if xmlfile.module_name.startswith("theme_") else "ir.asset"
+    )
+    _tag = "asset"
+    _tag_name_attr = "name"
+    _attribute_mapping = {
+        "name": "name",
+    }
+
+
+class XmlReport(XmlSpecialTag):
+    """Representation of an Odoo XML report (`<report>` tag)."""
+
+    _model = "ir.actions.report"
+    _tag = "report"
+    _tag_name_attr = "string"
+    _attribute_mapping = {
+        "string": "name",
+        "model": "model",
+        "report_type": "report_type",
+        "name": "report_name",
+        "file": "report_file",
+        "print_report_name": "print_report_name",
+    }
+
+
+class XmlActWindow(XmlSpecialTag):
+    """Representation of an Odoo XML act_window (`<act_window>` tag)."""
+
+    _model = "ir.actions.act_window"
+    _tag = "act_window"
+    _tag_name_attr = "name"
+    _attribute_mapping = {
+        "name": "name",
+        "res_model": "res_model",
+        "src_model": "src_model",
+        "view_mode": "view_mode",
+        "view_type": "view_type",
+        "target": "target",
+        "multi": "multi",
+        "key2": "key2",
+        "groups": "groups_id",
+        "context": "context",
+    }
+    _default_data = {"type": "ir.actions.act_window"}
+
+
+# Backend tags can be found in 'odoo/tools/convert.py',
+# method 'xml_import.__init__()'.
+# NOTE:
+#   - only tags from Odoo >= 11.0 are supported. Tags such as <workflow> or
+#     <ir_set> are not part of them (dropped in Odoo 11.0).
+#   - <delete>, <function> and <assert> tags are not added neither as they're not
+#     representing resources that can be used in code or reverse dependencies
+TAGS = {
+    "record": XmlRecord,
+    "template": XmlTemplate,
+    "menuitem": XmlMenuItem,
+    "asset": XmlAsset,
+    "report": XmlReport,
+    "act_window": XmlActWindow,
+}
+IGNORED_TAGS = [
+    "delete",
+    "function",
+    "assert",  # Odoo <= 12.0, old way of writing tests
+]

--- a/odoo_addons_parser/module.py
+++ b/odoo_addons_parser/module.py
@@ -10,6 +10,8 @@ import typing
 import pygount
 
 from .code import PyFile
+from .data_csv import CsvFile
+from .data_xml import XmlFile
 
 if typing.TYPE_CHECKING:
     from .repository import RepositoryParser
@@ -27,6 +29,7 @@ class ModuleParser:
         repo_parser: typing.Optional["RepositoryParser"] = None,
         code_stats: bool = True,
         scan_models: bool = True,
+        scan_data: bool = True,
     ):
         self.folder_path = pathlib.Path(folder_path).resolve()
         if not self.folder_path.exists():
@@ -37,9 +40,12 @@ class ModuleParser:
         self.repo_parser = repo_parser
         self._code_stats = code_stats
         self._scan_models = scan_models
+        self._scan_data = scan_data
         self.summary = pygount.ProjectSummary()
         self.code = {}
         self.models = {}
+        self.data = {}
+        self.demo = {}
         self._run()
 
     @staticmethod
@@ -82,6 +88,8 @@ class ModuleParser:
                 self._run_code_stats(file_path)
             if self._scan_models and file_path.suffix == ".py":
                 self._run_scan_models(file_path)
+            if self._scan_data and file_path.suffix in [".xml", ".csv"]:
+                self._run_scan_data(file_path)
         if self._code_stats:
             summaries = dict.fromkeys(self.languages, 0)
             for summary in self.summary.language_to_language_summary_map.values():
@@ -134,6 +142,47 @@ class ModuleParser:
                     self.models[key]["name"] = key
                     del self.models[key]["inherit"]
 
+    def _run_scan_data(self, file_path: pathlib.Path):
+        """Parse XML and CSV files and extract data records."""
+        manifest = self.manifest
+        data_paths = [pathlib.Path(path) for path in manifest.get("data", [])]
+        demo_paths = [pathlib.Path(path) for path in manifest.get("demo", [])]
+        try:
+            # Make file path relative to module path for consistency
+            relative_file_path = file_path.relative_to(self.folder_path)
+            # Ignore frontend (static) and tests files
+            if relative_file_path.parts[0] in ("static", "tests"):
+                return
+            # Backend files
+            else:
+                # Classify the file as data/demo or not loaded
+                demo = loaded = False
+                if relative_file_path in data_paths:
+                    loaded = True
+                elif relative_file_path in demo_paths:
+                    loaded = True
+                    demo = True
+                # Handle different file types
+                if file_path.suffix == ".xml":
+                    xml_file = XmlFile(self.folder_path, file_path, loaded=loaded)
+                    file_data = xml_file.to_dict()
+                elif file_path.suffix == ".csv":
+                    csv_file = CsvFile(self.folder_path, file_path, loaded=loaded)
+                    file_data = csv_file.to_dict()
+                else:
+                    return
+                # Merge into self.data or self.demo structure
+                collection = self.demo if demo else self.data
+                for model_name, records in file_data.items():
+                    if model_name not in collection:
+                        collection[model_name] = []
+                    collection[model_name].extend(records)
+        except NotImplementedError:
+            _logger.error(f"Unable to parse data file {file_path}")
+            raise
+        except Exception as exc:
+            _logger.warning(f"Unable to parse data file {file_path}: {exc}")
+
     def to_dict(self) -> dict:
         data = {
             "name": self.name,
@@ -143,4 +192,9 @@ class ModuleParser:
             data["code"] = self.code
         if self._scan_models:
             data["models"] = self.models
+        if self._scan_data:
+            if self.data:
+                data["data"] = self.data
+            if self.demo:
+                data["demo"] = self.demo
         return data

--- a/odoo_addons_parser/tests/common.py
+++ b/odoo_addons_parser/tests/common.py
@@ -22,13 +22,20 @@ class CommonCase(unittest.TestCase):
             "CSS": 0,
             "JavaScript": 0,
             "Python": 42,
-            "XML": 14,
+            "XML": 115,
         }
         cls.module_manifest = {
             "author": "Camptocamp, Odoo Community Association (OCA)",
             "category": "Test Module",
-            "data": ["views/res_partner.xml"],
-            "demo": [],
+            "data": [
+                "security/ir.model.access.csv",
+                "data/res_partner.xml",
+                "views/res_partner.xml",
+                "views/assets.xml",
+                "reports/reports.xml",
+                "reports/templates.xml",
+            ],
+            "demo": ["demo/res_partner.xml"],
             "depends": ["base"],
             "installable": True,
             "license": "AGPL-3",
@@ -153,12 +160,244 @@ class CommonCase(unittest.TestCase):
                 "type": "Model",
             },
         }
-        cls.module_to_dict = {
-            "name": cls.module_name,
-            "code": cls.module_code_stats,
-            "manifest": cls.module_manifest,
-            "models": cls.module_models,
+        cls.module_data = {
+            "ir.model.access": [
+                {
+                    "id": "access_res_partner_group_account",
+                    "model": "ir.model.access",
+                    "file_path": "security/ir.model.access.csv",
+                    "loaded": True,
+                    "data": {
+                        "id": "access_res_partner_group_account",
+                        "name": "res_partner group account",
+                        "model_id": "model_res_partner",
+                        "group_id": "group_user",
+                        "perm_read": "1",
+                        "perm_write": "1",
+                        "perm_create": "1",
+                        "perm_unlink": "0",
+                    },
+                },
+            ],
+            "ir.ui.view": [
+                {
+                    "id": "res_partner_form_view",
+                    "model": "ir.ui.view",
+                    "type": "normal",
+                    "target_model": "res.partner",
+                    "name": "res.partner.form.inherit",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {
+                        "model": "res.partner",
+                        "inherit_id": "base.res_partner_form_view",
+                        "arch": '\n            <field name="name" position="after">\n                <field name="custom_field" />\n                <field name="computed_field" />\n            </field>\n        ',
+                        "name": "res.partner.form.inherit",
+                    },
+                },
+                {
+                    "id": "res_partner_tree_view",
+                    "model": "ir.ui.view",
+                    "type": "normal",
+                    "target_model": "res.partner",
+                    "name": "res.partner.tree",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {
+                        "model": "res.partner",
+                        "arch": '\n            <tree>\n                <field name="name" />\n                <field name="custom_field" />\n            </tree>\n        ',
+                        "name": "res.partner.tree",
+                    },
+                },
+                {
+                    "id": "report_contact_badge",
+                    "model": "ir.ui.view",
+                    "type": "qweb",
+                    "name": "report_contact_badge",
+                    "file_path": "reports/templates.xml",
+                    "loaded": True,
+                    "data": {
+                        "arch": '<template id="report_contact_badge">\n        <t t-call="web.html_container">\n            <t t-foreach="docs" t-as="doc">\n                <h1 t-out="doc.name" />\n            </t>\n        </t>\n    </template>\n\n',
+                    },
+                },
+            ],
+            "ir.actions.act_window": [
+                {
+                    "id": "res_partner_action",
+                    "model": "ir.actions.act_window",
+                    "name": "Contacts",
+                    "target_model": "res.partner",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {
+                        "name": "Contacts",
+                        "type": "ir.actions.act_window",
+                        "res_model": "res.partner",
+                        "view_type": "form",
+                        "view_id": "res_partner_view_tree",
+                    },
+                },
+                {
+                    "id": "act_window_partner_simple",
+                    "model": "ir.actions.act_window",
+                    "name": "Partner Simple Action",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {
+                        "name": "Partner Simple Action",
+                        "type": "ir.actions.act_window",
+                        "res_model": "res.partner",
+                        "view_mode": "tree,form",
+                        "view_type": "tree",
+                        "target": "current",
+                    },
+                },
+            ],
+            "ir.actions.report": [
+                {
+                    "id": "action_report_badge",
+                    "model": "ir.actions.report",
+                    "name": "Badge",
+                    "file_path": "reports/reports.xml",
+                    "loaded": True,
+                    "data": {
+                        "name": "Badge",
+                        "model": "res.partner",
+                        "report_type": "qweb-pdf",
+                        "report_name": "module.report_contact_badge",
+                        "report_file": "module.report_contact_badge",
+                        "print_report_name": "'Badge - %s - %s' % (object.name or '', object.name)",
+                        "binding_model_id": "model_res_partner",
+                        "binding_type": "report",
+                    },
+                },
+                {
+                    "id": "report_partner_simple",
+                    "model": "ir.actions.report",
+                    "name": "Partner Simple Report",
+                    "file_path": "reports/reports.xml",
+                    "loaded": True,
+                    "data": {
+                        "name": "Partner Simple Report",
+                        "model": "res.partner",
+                        "report_type": "qweb-pdf",
+                        "report_name": "module_test.report_partner_simple",
+                        "report_file": "module_test.report_partner_simple",
+                    },
+                },
+                {
+                    "id": "report_partner_detailed",
+                    "model": "ir.actions.report",
+                    "name": "Partner Detailed Report",
+                    "file_path": "reports/reports.xml",
+                    "loaded": True,
+                    "data": {
+                        "name": "Partner Detailed Report",
+                        "model": "res.partner",
+                        "report_type": "qweb-pdf",
+                        "report_name": "module_test.report_partner_detailed",
+                        "report_file": "module_test.report_partner_detailed",
+                        "print_report_name": "'Partner Report - %s' % (object.name)",
+                    },
+                },
+            ],
+            "ir.ui.menu": [
+                {
+                    "id": "main_menu",
+                    "model": "ir.ui.menu",
+                    "name": "Main menu",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {"name": "Main menu", "parent_id": "base.root_menu"},
+                },
+                {
+                    "id": "submenu_menu",
+                    "model": "ir.ui.menu",
+                    "name": "Submenu",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {"name": "Submenu", "parent_id": "main_menu"},
+                },
+                {
+                    "id": "res_partner_menu",
+                    "model": "ir.ui.menu",
+                    "file_path": "views/res_partner.xml",
+                    "loaded": True,
+                    "data": {
+                        "action": "res_partner_action",
+                        "parent_id": "submenu_menu",
+                    },
+                },
+            ],
+            "ir.asset": [
+                {
+                    "id": "contact_badge_scss",
+                    "model": "ir.asset",
+                    "name": "Contact Badge SCSS",
+                    "file_path": "views/assets.xml",
+                    "loaded": True,
+                    "data": {"name": "Contact Badge SCSS"},
+                }
+            ],
+            "res.partner": [
+                {
+                    "id": "director",
+                    "model": "res.partner",
+                    "name": "Director",
+                    "file_path": "data/res_partner.xml",
+                    "loaded": True,
+                    "noupdate": True,
+                    "data": {"name": "Director"},
+                },
+                {
+                    "id": "accountant",
+                    "model": "res.partner",
+                    "name": "Accountant",
+                    "file_path": "data/res_partner.xml",
+                    "loaded": True,
+                    "data": {"name": "Accountant"},
+                },
+            ],
         }
+        cls.module_demo = {
+            "res.partner": [
+                {
+                    "id": "employee",
+                    "model": "res.partner",
+                    "name": "Employee",
+                    "file_path": "demo/res_partner.xml",
+                    "loaded": True,
+                    "data": {"name": "Employee"},
+                }
+            ]
+        }
+
+        cls.module_to_dict = cls._order_mod_data(
+            {
+                "name": cls.module_name,
+                "code": cls.module_code_stats,
+                "manifest": cls.module_manifest,
+                "models": cls.module_models,
+                "data": cls.module_data,
+                "demo": cls.module_demo,
+            }
+        )
+
+    @classmethod
+    def _order_mod_data(cls, data):
+        """Order module data to ease comparison between Python versions."""
+        for model, records in data["data"].items():
+            data["data"][model] = sorted(records, key=lambda rec: rec["id"])
+        for model, records in data["demo"].items():
+            data["demo"][model] = sorted(records, key=lambda rec: rec["id"])
+        return data
+
+    @classmethod
+    def _order_repo_data(cls, data):
+        """Order repository data to ease comparison between Python versions."""
+        for module_name, mod_data in data.items():
+            cls._order_mod_data(mod_data)
+        return data
 
     @classmethod
     def _run_module_parser(cls, **kw):

--- a/odoo_addons_parser/tests/repo/module_test/__manifest__.py
+++ b/odoo_addons_parser/tests/repo/module_test/__manifest__.py
@@ -8,7 +8,14 @@
     "website": "https://example.com/odoo-addons-parser",
     "license": "AGPL-3",
     "depends": ["base"],
-    "data": ["views/res_partner.xml"],
-    "demo": [],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/res_partner.xml",
+        "views/res_partner.xml",
+        "views/assets.xml",
+        "reports/reports.xml",
+        "reports/templates.xml",
+    ],
+    "demo": ["demo/res_partner.xml"],
     "installable": True,
 }

--- a/odoo_addons_parser/tests/repo/module_test/data/res_partner.xml
+++ b/odoo_addons_parser/tests/repo/module_test/data/res_partner.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <data noupdate="1">
+
+        <record id="director" model="res.partner">
+            <field name="name">Director</field>
+        </record>
+
+    </data>
+
+    <record id="accountant" model="res.partner">
+        <field name="name">Accountant</field>
+    </record>
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/demo/res_partner.xml
+++ b/odoo_addons_parser/tests/repo/module_test/demo/res_partner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="employee" model="res.partner">
+        <field name="name">Employee</field>
+    </record>
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/reports/reports.xml
+++ b/odoo_addons_parser/tests/repo/module_test/reports/reports.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="action_report_badge" model="ir.actions.report">
+        <field name="name">Badge</field>
+        <field name="model">res.partner</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">module.report_contact_badge</field>
+        <field name="report_file">module.report_contact_badge</field>
+        <field name="print_report_name">'Badge - %s - %s' % (object.name or '', object.name)</field>
+        <field name="binding_model_id" ref="model_res_partner"/>
+        <field name="binding_type">report</field>
+    </record>
+
+    <!-- 'report' tag supported until Odoo 16.0 -->
+    <report
+        id="report_partner_simple"
+        string="Partner Simple Report"
+        model="res.partner"
+        report_type="qweb-pdf"
+        name="module_test.report_partner_simple"
+        file="module_test.report_partner_simple"
+    />
+
+    <report
+        id="report_partner_detailed"
+        string="Partner Detailed Report"
+        model="res.partner"
+        report_type="qweb-pdf"
+        name="module_test.report_partner_detailed"
+        file="module_test.report_partner_detailed"
+        print_report_name="'Partner Report - %s' % (object.name)"
+    />
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/reports/templates.xml
+++ b/odoo_addons_parser/tests/repo/module_test/reports/templates.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <template id="report_contact_badge">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <h1 t-out="doc.name" />
+            </t>
+        </t>
+    </template>
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/security/ir.model.access.csv
+++ b/odoo_addons_parser/tests/repo/module_test/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_res_partner_group_account","res_partner group account","model_res_partner","group_user",1,1,1,0

--- a/odoo_addons_parser/tests/repo/module_test/tests/test.xml
+++ b/odoo_addons_parser/tests/repo/module_test/tests/test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="contact_test" model="res.partner">
+        <field name="name">Contact not included</field>
+    </record>
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/views/assets.xml
+++ b/odoo_addons_parser/tests/repo/module_test/views/assets.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Sebastien Alix <https://github.com/sebalix
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <asset id="contact_badge_scss" name="Contact Badge SCSS" active="True">
+        <field name="key">module_test.contact_badge_scss</field>
+        <bundle>web.assets_frontend</bundle>
+        <path>/module_test/static/src/scss/contact_badge.scss</path>
+    </asset>
+
+</odoo>

--- a/odoo_addons_parser/tests/repo/module_test/views/res_partner.xml
+++ b/odoo_addons_parser/tests/repo/module_test/views/res_partner.xml
@@ -3,16 +3,50 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
-  <record id="res_partner_form_view" model="ir.ui.view">
-    <field name="name">res.partner.form.inherit</field>
-    <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.res_partner_form_view"/>
-    <field name="arch" type="xml">
-      <field name="name" position="after">
-        <field name="custom_field" />
-        <field name="computed_field" />
-      </field>
-    </field>
-  </record>
+    <record id="res_partner_form_view" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.res_partner_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="custom_field" />
+                <field name="computed_field" />
+            </field>
+        </field>
+    </record>
+
+    <record id="res_partner_tree_view" model="ir.ui.view">
+        <field name="name">res.partner.tree</field>
+        <field name="model">res.partner</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="custom_field" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="res_partner_action" model="ir.actions.act_window">
+        <field name="name">Contacts</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">res.partner</field>
+        <field name="view_type">form</field>
+        <field name="view_id" ref="res_partner_view_tree" />
+    </record>
+
+    <menuitem id="main_menu" parent="base.root_menu" name="Main menu" >
+        <menuitem id="submenu_menu" name="Submenu">
+            <menuitem id="res_partner_menu" action="res_partner_action" />
+        </menuitem>
+    </menuitem>
+
+    <act_window
+        id="act_window_partner_simple"
+        name="Partner Simple Action"
+        res_model="res.partner"
+        view_mode="tree,form"
+        view_type="tree"
+        target="current"
+    />
 
 </odoo>

--- a/odoo_addons_parser/tests/test_module.py
+++ b/odoo_addons_parser/tests/test_module.py
@@ -16,6 +16,7 @@ class TestModule(common.CommonCase):
         self.assertDictEqual(mod.manifest, self.module_manifest)
         self.assertDictEqual(mod.code, self.module_code_stats)
         self.assertDictEqual(mod.models, self.module_models)
+        self.assertEqual(set(mod.data), set(self.module_data))
 
     def test_init_no_code_stats(self):
         mod = self._run_module_parser(code_stats=False)
@@ -24,6 +25,7 @@ class TestModule(common.CommonCase):
         self.assertDictEqual(mod.manifest, self.module_manifest)
         self.assertFalse(mod.code)
         self.assertDictEqual(mod.models, self.module_models)
+        self.assertEqual(set(mod.data), set(self.module_data))
 
     def test_init_no_scan_models(self):
         mod = self._run_module_parser(scan_models=False)
@@ -32,6 +34,16 @@ class TestModule(common.CommonCase):
         self.assertDictEqual(mod.manifest, self.module_manifest)
         self.assertDictEqual(mod.code, self.module_code_stats)
         self.assertFalse(mod.models)
+        self.assertEqual(set(mod.data), set(self.module_data))
+
+    def test_init_no_scan_data(self):
+        mod = self._run_module_parser(scan_data=False)
+        self.assertEqual(mod.name, self.module_name)
+        self.assertTrue(mod.file_paths)
+        self.assertDictEqual(mod.manifest, self.module_manifest)
+        self.assertDictEqual(mod.code, self.module_code_stats)
+        self.assertDictEqual(mod.models, self.module_models)
+        self.assertFalse(mod.data)
 
     def test_init_folder_not_exist(self):
         with self.assertRaises(ValueError):
@@ -44,16 +56,26 @@ class TestModule(common.CommonCase):
 
     def test_to_dict(self):
         mod = self._run_module_parser()
-        self.assertDictEqual(mod.to_dict(), self.module_to_dict)
+        mod_data = self._order_mod_data(mod.to_dict())
+        self.assertDictEqual(mod_data, self.module_to_dict)
 
     def test_to_dict_no_code_stats(self):
         mod = self._run_module_parser(code_stats=False)
         mod_to_dict = copy.deepcopy(self.module_to_dict)
         del mod_to_dict["code"]
-        self.assertDictEqual(mod.to_dict(), mod_to_dict)
+        mod_data = self._order_mod_data(mod.to_dict())
+        self.assertDictEqual(mod_data, mod_to_dict)
 
     def test_to_dict_no_scan_models(self):
         mod = self._run_module_parser(scan_models=False)
         mod_to_dict = copy.deepcopy(self.module_to_dict)
         del mod_to_dict["models"]
+        mod_data = self._order_mod_data(mod.to_dict())
+        self.assertDictEqual(mod_data, mod_to_dict)
+
+    def test_to_dict_no_scan_data(self):
+        mod = self._run_module_parser(scan_data=False)
+        mod_to_dict = copy.deepcopy(self.module_to_dict)
+        del mod_to_dict["data"]
+        del mod_to_dict["demo"]
         self.assertDictEqual(mod.to_dict(), mod_to_dict)

--- a/odoo_addons_parser/tests/test_repository.py
+++ b/odoo_addons_parser/tests/test_repository.py
@@ -14,16 +14,19 @@ class TestRepository(common.CommonCase):
 
     def test_to_dict(self):
         repo = self._run_repo_parser()
-        self.assertDictEqual(repo.to_dict(), {self.module_name: self.module_to_dict})
+        repo_data = self._order_repo_data(repo.to_dict())
+        self.assertDictEqual(repo_data, {self.module_name: self.module_to_dict})
 
     def test_to_dict_no_code_stats(self):
         repo = self._run_repo_parser(code_stats=False)
         mod_to_dict = copy.deepcopy(self.module_to_dict)
         del mod_to_dict["code"]
-        self.assertDictEqual(repo.to_dict(), {self.module_name: mod_to_dict})
+        repo_data = self._order_repo_data(repo.to_dict())
+        self.assertDictEqual(repo_data, {self.module_name: mod_to_dict})
 
     def test_to_dict_no_scan_models(self):
         repo = self._run_repo_parser(scan_models=False)
         mod_to_dict = copy.deepcopy(self.module_to_dict)
         del mod_to_dict["models"]
-        self.assertDictEqual(repo.to_dict(), {self.module_name: mod_to_dict})
+        repo_data = self._order_repo_data(repo.to_dict())
+        self.assertDictEqual(repo_data, {self.module_name: mod_to_dict})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,18 @@ readme = "README.md"
 keywords = ["odoo", "oca", "analyze", "parser", "collect", "modules", "addons"]
 license = {file = "LICENSE"}
 classifiers = [
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3 :: Only",
     "Framework :: Odoo",
 ]
 dependencies = [


### PR DESCRIPTION
Extract data from Odoo modules with `scan_data` parameter (default to `True`):
```python
from odoo_addons_parser import ModuleParser
ModuleParser("odoo/module/path", scan_data=True)
```

TODO:
- [x] Scan backend XML data
- [x] Scan backend CSV data
- [x] Flag backend data as `data` or `demo` (based on manifest)
- [x] Add support for `<report>` tag
- [x] Add support for `<act_window>` tag
- [ ] <s>Scan frontend XML data (to move in a new PR? useful?)</s> [moved there for now](https://github.com/sebalix/odoo-addons-parser/tree/dev-xml-data-frontend)