### PR TITLE
[FIX] ModuleParser, XML scan: ignore xpath tags under root tag

### DIFF
--- a/odoo_addons_parser/data_xml.py
+++ b/odoo_addons_parser/data_xml.py
@@ -414,4 +414,5 @@ IGNORED_TAGS = [
     "delete",
     "function",
     "assert",  # Odoo <= 12.0, old way of writing tests
+    "xpath",  # OCA/OpenUpgrade#19.0 using it in noupdate.xml files
 ]


### PR DESCRIPTION
Error triggered when scanning https://github.com/OCA/OpenUpgrade/blob/19.0/openupgrade_scripts/scripts/uom/19.0.1.0/noupdate_changes-transformation.xml